### PR TITLE
Has one Hash should default to {}

### DIFF
--- a/lib/mongoid/alize/callbacks/from/one.rb
+++ b/lib/mongoid/alize/callbacks/from/one.rb
@@ -30,7 +30,7 @@ module Mongoid
           def define_fields
             ensure_field_not_defined!(prefixed_name, klass)
             klass.class_eval <<-CALLBACK, __FILE__, __LINE__ + 1
-              field :#{prefixed_name}, :type => Hash, :default => nil
+              field :#{prefixed_name}, :type => Hash, :default => {}
             CALLBACK
 
             define_fields_method

--- a/spec/mongoid/alize/callbacks/from/one_spec.rb
+++ b/spec/mongoid/alize/callbacks/from/one_spec.rb
@@ -21,10 +21,10 @@ describe Mongoid::Alize::Callbacks::From::One do
         Head.fields["person_fields"].type.should == Hash
       end
 
-      it "should default the field to nil" do
+      it "should default the field to empty" do
         callback = new_callback
         callback.send(:define_fields)
-        Head.new.person_fields.should be_nil
+        Head.new.person_fields.should == {}
       end
 
       it "should raise an already defined field error if the field already exists" do


### PR DESCRIPTION
This is analogous to`has many` Array defaulting to []

Reduces the need for nil-checking.
