### PR TITLE
Fixing mongoid_4? version check

### DIFF
--- a/lib/mongoid/alize/to_callback.rb
+++ b/lib/mongoid/alize/to_callback.rb
@@ -154,11 +154,9 @@ module Mongoid
       def direction
         "to"
       end
-
-	    def mongoid_4?
-			  version_arry = Mongoid::VERSION.split('.').map{|s|s.to_i}
-			  version_arry[0] >= 4 ? true : false
-	    end
+      def mongoid_4?
+	!(Mongoid::VERSION =~ /^4\./).nil?
+      end
     end
   end
 end

--- a/lib/mongoid/alize/to_callback.rb
+++ b/lib/mongoid/alize/to_callback.rb
@@ -155,9 +155,10 @@ module Mongoid
         "to"
       end
 
-      def mongoid_4?
-        Mongoid::VERSION =~ /^4\./
-      end
+	    def mongoid_4?
+			  version_arry = Mongoid::VERSION.split('.').map{|s|s.to_i}
+			  version_arry[0] >= 4 ? true : false
+	    end
     end
   end
 end


### PR DESCRIPTION
The mongoid_4? method/check was previously returning 0 instead of true/false.  As a result, previous fixes were not firing and a wrong number of arguments error occurred.

Fixed check to see if first version # >= to mongoid 4 so previous fixes work.