### PR TITLE
Fix error: "alize does not work with default scope"

### DIFF
--- a/lib/mongoid/alize/config.rb
+++ b/lib/mongoid/alize/config.rb
@@ -1,0 +1,17 @@
+require 'active_support/configurable'
+
+module Mongoid
+  module Alize
+    include ActiveSupport::Configurable
+
+    config_accessor :unscoped do
+      false
+    end
+
+    class << self
+      def setup
+        yield config
+      end
+    end
+  end
+end

--- a/lib/mongoid/alize/to_callback.rb
+++ b/lib/mongoid/alize/to_callback.rb
@@ -121,7 +121,8 @@ module Mongoid
       end
 
       def iterable_relation
-        "[self.#{relation}].flatten.compact"
+        scope = Mongoid::Alize.config.unscoped ? 'unscoped' : 'scoped'
+        "[self.#{relation}.#{scope}].flatten.compact"
       end
 
       def set_callback

--- a/lib/mongoid_alize.rb
+++ b/lib/mongoid_alize.rb
@@ -1,3 +1,5 @@
+require 'mongoid/alize/config'
+
 require 'mongoid/alize/errors/alize_error'
 require 'mongoid/alize/errors/invalid_field'
 require 'mongoid/alize/errors/already_defined_field'


### PR DESCRIPTION
This pull request added configuration options to disable default_scope.

Mongoid::Alize.setup do |config|
  config.unscoped = true
end
