### PR TITLE
Support Mongoid 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ log/*
 *.gem
 Gemfile.lock
 Gemfile.mongoid-two.lock
+Gemfile.mongoid-three.lock
 Gemfile.mongoid-four.lock
 bin
 .bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
 gemfile:
   - Gemfile
   - Gemfile.mongoid-two
+  - Gemfile.mongoid-three
   - Gemfile.mongoid-four
 matrix:
   exclude:

--- a/Gemfile.mongoid-three
+++ b/Gemfile.mongoid-three
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 group :development, :test do
   gem 'rake'
-  gem 'mongoid', '~> 5'
+  gem 'mongoid', '~> 3'
 
   gem 'rspec'
   gem 'rr'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Features of Mongoid Alizé
 - The [wiki](https://github.com/dzello/mongoid_alize/wiki), soon to be full of war stories and protips.
 - Supports mongoid 4+ (experimental), mongoid 3+ and mongoid 2.4+
 
+Compatibility
+-------------
+Mongoid Alizé supports Mongoid versions 2, 3, 4, and now 5.
+
 Installation
 ------------
 Add the gem to your `Gemfile`:
@@ -142,6 +146,9 @@ Check out [spec/mongoid_alize_spec.rb](https://github.com/dzello/mongoid_alize/b
 
 Changelog
 ---------
+### Release 0.5.0
+Now supporting Mongoid 5.
+
 ### Release 0.4.2
 Several issues and pull requests fixed. Thanks [johnnyshields](https://github.com/johnnyshields)!
 

--- a/lib/mongoid/alize/to_callback.rb
+++ b/lib/mongoid/alize/to_callback.rb
@@ -91,15 +91,15 @@ module Mongoid
       end
 
       def relation_set(field, value)
-        mongoid_4? ? "relation.set(#{field} => #{value})" : "relation.set(#{field}, #{value})"
+        mongoid_four_or_newer? ? "relation.set(#{field} => #{value})" : "relation.set(#{field}, #{value})"
       end
 
       def relation_pull(field, value)
-        mongoid_4? ? "relation.pull(#{field} => #{value})" : "relation.pull(#{field}, #{value})"
+        mongoid_four_or_newer? ? "relation.pull(#{field} => #{value})" : "relation.pull(#{field}, #{value})"
       end
 
       def relation_push(field, value)
-        mongoid_4? ? "relation.push(#{field} => #{value})" : "relation.push(#{field}, #{value})"
+        mongoid_four_or_newer? ? "relation.push(#{field} => #{value})" : "relation.push(#{field}, #{value})"
       end
 
       def is_one?
@@ -155,9 +155,10 @@ module Mongoid
         "to"
       end
 
-      def mongoid_4?
-        Mongoid::VERSION =~ /^4\./
+      def mongoid_four_or_newer?
+        Mongoid::VERSION.split('.').first.to_i >= 4
       end
+
     end
   end
 end

--- a/mongoid_alize.gemspec
+++ b/mongoid_alize.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "mongoid_alize"
-  s.version     = "0.4.3"
+  s.version     = "0.5.0"
   s.author      = "Josh Dzielak"
   s.email       = "github_public@dz.oib.com"
   s.homepage    = "https://github.com/dzello/mongoid_alize"

--- a/run-specs-for-all-gemfiles.sh
+++ b/run-specs-for-all-gemfiles.sh
@@ -1,0 +1,4 @@
+BUNDLE_GEMFILE=Gemfile bundle install && bundle exec rake spec
+BUNDLE_GEMFILE=Gemfile.mongoid-two bundle install && bundle exec rake spec
+BUNDLE_GEMFILE=Gemfile.mongoid-three bundle install && bundle exec rake spec
+BUNDLE_GEMFILE=Gemfile.mongoid-four bundle install && bundle exec rake spec

--- a/spec/app/models/head.rb
+++ b/spec/app/models/head.rb
@@ -2,7 +2,7 @@ class Head
   include Mongoid::Document
   include Mongoid::Alize
 
-  if SpecHelper.mongoid_4?
+  if SpecHelper.mongoid_four_or_newer?
     include Mongoid::Attributes::Dynamic
   end
 

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -2,14 +2,14 @@ class Person
   include Mongoid::Document
   include Mongoid::Alize
 
-  if SpecHelper.mongoid_4?
+  if SpecHelper.mongoid_four_or_newer?
     include Mongoid::Attributes::Dynamic
   end
 
   field :name, type: String
   field :created_at, type: Time
 
-  if SpecHelper.mongoid_3? || SpecHelper.mongoid_4?
+  if SpecHelper.mongoid_three_or_newer?
     field :my_date, type: Date
     field :my_datetime, type: DateTime
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,23 +7,37 @@ unless ENV['CI']
 end
 
 module SpecHelper
+
+  # for mongoize_spec
   def self.mongoid_3?
-    defined?(Mongoid::VERSION) && Mongoid::VERSION =~ /^3/
+    defined?(Mongoid::VERSION) && Mongoid::VERSION.split('.').first.to_i == 3
   end
 
-  def self.mongoid_4?
-    defined?(Mongoid::VERSION) && Mongoid::VERSION =~ /^4/
+  # different connection scheme starting with three
+  def self.mongoid_three_or_newer?
+    defined?(Mongoid::VERSION) && Mongoid::VERSION.split('.').first.to_i >= 3
   end
+
+  # dynamic attributes required starting with four
+  def self.mongoid_four_or_newer?
+    defined?(Mongoid::VERSION) && Mongoid::VERSION.split('.').first.to_i >= 4
+  end
+
 end
 
 Mongoid.configure do |config|
-  if SpecHelper.mongoid_3? || SpecHelper.mongoid_4?
-    config.connect_to("mongoid_alize_test")
+
+  if defined?(Moped)
     Moped.logger = Logger.new($stdout)
     Moped.logger.level = Logger::INFO
   else
     logger = Logger.new($stdout)
     logger.level = Logger::INFO
+  end
+
+  if SpecHelper.mongoid_three_or_newer?
+    config.connect_to("mongoid_alize_test")
+  else
     config.master = Mongo::Connection.new("localhost", 27017,
                     :logger => logger).db("mongoid_alize_test")
   end


### PR DESCRIPTION
There were places in the code where mongoid 4 is checked for in order to follow conventions introduced after mongoid 3. These checks needed to recognize mongoid 5 (and later versions) as well. 