### PR TITLE
Add support for Mongoid 7.0 and 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 services: mongodb
 script: "bundle exec rspec spec"
 rvm:
-  - 2.5.1
-  - 2.3.7
+  - 2.5.7
+  - 2.6.6
 gemfile:
   - Gemfile
 env:
@@ -13,5 +13,5 @@ env:
   - RAILS_VERSION=5.0 MONGOID_VERSION=6.1
   - RAILS_VERSION=5.1 MONGOID_VERSION=6.2
   - RAILS_VERSION=5.2 MONGOID_VERSION=6.4
-services:
-  - mongodb
+  - RAILS_VERSION=6.0.3 MONGOID_VERSION=7.0.8
+  - RAILS_VERSION=6.0.3 MONGOID_VERSION=7.1.2

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source 'https://rubygems.org'
 
-rails_version = ENV['RAILS_VERSION'] || "5.2"
-gem "rails", rails_version
+rails_version = ENV['RAILS_VERSION'] || "6.0.3"
+gem "rails", "~> #{rails_version}"
 
-mongoid_version = ENV['MONGOID_VERSION'] || "6.4"
-gem "mongoid", mongoid_version
+mongoid_version = ENV['MONGOID_VERSION'] || "7.1.2"
+gem "mongoid", "~> #{mongoid_version}"
 
 gem "mongoid-compatibility"
 

--- a/lib/mongoid/alize/macros.rb
+++ b/lib/mongoid/alize/macros.rb
@@ -76,12 +76,22 @@ module Mongoid
       end
 
       def _alize_relation_types
-        one  = Mongoid::Relations::One
-        many = Mongoid::Relations::Many
+        if Mongoid::Compatibility::Version.mongoid7_or_newer?
+          one  = Mongoid::Association::One
+          many = Mongoid::Association::Many
+        else
+          one  = Mongoid::Relations::One
+          many = Mongoid::Relations::Many
+        end
 
         def (many).==(klass)
-          [Mongoid::Relations::Many,
-           Mongoid::Relations::Referenced::Many].map(&:name).include?(klass.name)
+          if Mongoid::Compatibility::Version.mongoid7_or_newer?
+            [Mongoid::Association::Many,
+             Mongoid::Association::Referenced::HasMany::Proxy].map(&:name).include?(klass.name)
+          else
+            [Mongoid::Relations::Many,
+             Mongoid::Relations::Referenced::Many].map(&:name).include?(klass.name)
+          end
         end
 
         [one, many]

--- a/lib/mongoid/alize/to_callback.rb
+++ b/lib/mongoid/alize/to_callback.rb
@@ -109,16 +109,30 @@ module Mongoid
       end
 
       def is_one?
-        if inverse_relation
-          if self.inverse_metadata.relation.superclass == Mongoid::Relations::One
-            "true"
+        if Mongoid::Compatibility::Version.mongoid7_or_newer?
+          if inverse_relation
+            if self.inverse_metadata.relation.superclass == Mongoid::Association::One
+              "true"
+            else
+              "false"
+            end
           else
-            "false"
+            <<-RUBIES
+            (#{find_relation}.relation.superclass == Mongoid::Association::One)
+            RUBIES
           end
         else
-          <<-RUBIES
+          if inverse_relation
+            if self.inverse_metadata.relation.superclass == Mongoid::Relations::One
+              "true"
+            else
+              "false"
+            end
+          else
+            <<-RUBIES
             (#{find_relation}.relation.superclass == Mongoid::Relations::One)
-          RUBIES
+            RUBIES
+          end
         end
       end
 

--- a/spec/app/models/head.rb
+++ b/spec/app/models/head.rb
@@ -9,7 +9,13 @@ class Head
   field :size, type: Integer
   field :weight
 
-  if Mongoid::Compatibility::Version.mongoid6_or_newer?
+  if Mongoid::Compatibility::Version.mongoid7_or_newer?
+    # to whom it's attached
+    belongs_to :person, :inverse_of => :head, optional: true
+
+    # in whose possession it is
+    belongs_to :captor, :class_name => "Person", :inverse_of => :heads, optional: true
+  elsif Mongoid::Compatibility::Version.mongoid6_or_newer?
     # to whom it's attached
     belongs_to :person, optional: true
 

--- a/spec/app/models/person.rb
+++ b/spec/app/models/person.rb
@@ -15,7 +15,11 @@ class Person
   end
 
   # the attached head
-  has_one :head
+  if Mongoid::Compatibility::Version.mongoid7_or_newer?
+    has_one :head, :inverse_of => :person
+  else
+    has_one :head
+  end
 
   # the heads taken from others
   has_many :heads, :class_name => "Head", :inverse_of => :captor

--- a/spec/mongoid/alize/macros_spec.rb
+++ b/spec/mongoid/alize/macros_spec.rb
@@ -2,11 +2,19 @@ require 'spec_helper'
 
 describe Mongoid::Alize::Macros do
   def person_default_fields
-    ["name", "created_at", "my_date", "my_datetime", "want_ids", "seen_by_id", "above_type", "above_id"]
+    if Mongoid::Compatibility::Version.mongoid3?
+      ["name", "created_at", "want_ids", "seen_by_id", "above_type", "above_field", "above_id"]
+    else
+      ["name", "created_at", "my_date", "my_datetime", "want_ids", "seen_by_id", "above_type", "above_id"]
+    end
   end
 
   def head_default_fields
-    ["size", "weight", "person_id", "captor_id", "wanted_by_ids", "nearest_type", "nearest_id"]
+    if Mongoid::Compatibility::Version.mongoid3?
+      ["size", "weight", "person_id", "captor_id", "wanted_by_ids", "nearest_type", "nearest_field", "nearest_id"]
+    else
+      ["size", "weight", "person_id", "captor_id", "wanted_by_ids", "nearest_type", "nearest_id"]
+    end
   end
 
   describe "#alize_to and #alize_from" do

--- a/spec/mongoid/alize/macros_spec.rb
+++ b/spec/mongoid/alize/macros_spec.rb
@@ -69,10 +69,20 @@ describe Mongoid::Alize::Macros do
       end
 
       describe "when no inverse is present" do
-        it "should add only a from callback" do
-          Head.relations["admirer"].inverse.should be_nil
-          dont_allow(Mongoid::Alize::ToCallback).new
-          Head.alize(:admirer)
+        if Mongoid::Compatibility::Version.mongoid7_or_newer?
+          # For Mongoid 7, the admirer field has a default inverse set to :seen_by despite :inverse_of => nil
+          # This is an uncommon/ambiguous situation since in Head we define :inverse_of => nil, but
+          # on the other side, Person does not have an "admiree" or corresponding field.
+          it "should not add only a from callback" do
+            Head.relations["admirer"].inverse.should eq(:seen_by)
+            Head.alize(:admirer)
+          end
+        else
+          it "should add only a from callback" do
+            Head.relations["admirer"].inverse.should be_nil
+            dont_allow(Mongoid::Alize::ToCallback).new
+            Head.alize(:admirer)
+          end
         end
       end
     end

--- a/spec/mongoid/alize/macros_spec.rb
+++ b/spec/mongoid/alize/macros_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Mongoid::Alize::Macros do
   def person_default_fields
-    ["name", "created_at", "want_ids", "seen_by_id"]
+    ["name", "created_at", "my_date", "my_datetime", "want_ids", "seen_by_id", "above_type", "above_id"]
   end
 
   def head_default_fields
-    ["size", "weight", "person_id", "captor_id", "wanted_by_ids"]
+    ["size", "weight", "person_id", "captor_id", "wanted_by_ids", "nearest_type", "nearest_id"]
   end
 
   describe "#alize_to and #alize_from" do

--- a/spec/mongoid_alize_spec.rb
+++ b/spec/mongoid_alize_spec.rb
@@ -224,31 +224,55 @@ describe Mongoid::Alize do
       it "should denormalize all non-internal fields" do
         Head.send(:alize, :person)
         @head.save!
-        @head.person_fields.should == {
-          "name" => @name,
-          "created_at" => @person.created_at,
-          "my_date" => nil,
-          "my_datetime" => nil,
-          "seen_by_id" => nil,
-          "want_ids" => [],
-          "above_id" => nil,
-          "above_type" => nil
-        }
+        if Mongoid::Compatibility::Version.mongoid3?
+          @head.person_fields.should == {
+            "name" => @name,
+            "created_at" => @person.created_at,
+            "seen_by_id" => nil,
+            "want_ids" => [],
+            "above_id" => nil,
+            "above_field" => nil,
+            "above_type" => nil
+          }
+        else
+          @head.person_fields.should == {
+            "name" => @name,
+            "created_at" => @person.created_at,
+            "my_date" => nil,
+            "my_datetime" => nil,
+            "seen_by_id" => nil,
+            "want_ids" => [],
+            "above_id" => nil,
+            "above_type" => nil
+          }
+        end
       end
 
       it "should denormalize all non-internal fields" do
         Head.send(:alize, :person)
         @person.save!
-        @head.person_fields.should == {
-          "name" => @name,
-          "created_at" => @person.created_at,
-          "my_date" => nil,
-          "my_datetime" => nil,
-          "seen_by_id" => nil,
-          "want_ids" => [],
-          "above_id" => nil,
-          "above_type" => nil
-        }
+        if Mongoid::Compatibility::Version.mongoid3?
+          @head.person_fields.should == {
+            "name" => @name,
+            "created_at" => @person.created_at,
+            "seen_by_id" => nil,
+            "want_ids" => [],
+            "above_id" => nil,
+            "above_field" => nil,
+            "above_type" => nil
+          }
+        else
+          @head.person_fields.should == {
+            "name" => @name,
+            "created_at" => @person.created_at,
+            "my_date" => nil,
+            "my_datetime" => nil,
+            "seen_by_id" => nil,
+            "want_ids" => [],
+            "above_id" => nil,
+            "above_type" => nil
+          }
+        end
       end
     end
 

--- a/spec/mongoid_alize_spec.rb
+++ b/spec/mongoid_alize_spec.rb
@@ -227,8 +227,12 @@ describe Mongoid::Alize do
         @head.person_fields.should == {
           "name" => @name,
           "created_at" => @person.created_at,
+          "my_date" => nil,
+          "my_datetime" => nil,
           "seen_by_id" => nil,
-          "want_ids" => []
+          "want_ids" => [],
+          "above_id" => nil,
+          "above_type" => nil
         }
       end
 
@@ -238,8 +242,12 @@ describe Mongoid::Alize do
         @head.person_fields.should == {
           "name" => @name,
           "created_at" => @person.created_at,
+          "my_date" => nil,
+          "my_datetime" => nil,
           "seen_by_id" => nil,
-          "want_ids" => []
+          "want_ids" => [],
+          "above_id" => nil,
+          "above_type" => nil
         }
       end
     end


### PR DESCRIPTION
This pull adds support for Mongoid 7.0 and 7.1.  Mongoid 7+ had some major changes to the internal classes for relations (now called associations).

Summary of changes:

- Updated references to internal classes for associations.
- Mongoid 7 is a little stricter when it comes to defining associations, so specs had to be updated to add `inverse_of` in order to avoid Mongoid 7 runtime errors.
- `spec_helper.rb` had a bug where the association fields `nearest_id`, `nearest_type`, etc. were being incorrectly removed, causing a runtime error when running specs in Mongoid 7.  The field reset code had to be updated to properly restore fields between runs, and references to fields were also updated accordingly.
- Defining a `has_many` association with `inverse_of: nil` behaves differently under Mongoid 7.  Prior to Mongoid 7, this association has a nil inverse value, but under Mongoid 7, the association is assigned to a default inverse value. The spec in `macros_spec.rb` has been updated to pass under Mongoid 7 and to note this difference.
